### PR TITLE
Fix error in sparse apply! for CliffordOperators and add CPhase gate

### DIFF
--- a/src/SimpleClifford.jl
+++ b/src/SimpleClifford.jl
@@ -27,7 +27,7 @@ export @P_str, PauliOperator, ⊗, I, X, Y, Z, permute,
     apply!,
     CliffordOperator, @C_str,
     CliffordColumnForm, @Ccol_str,
-    CNOT, SWAP, Hadamard, Phase, CliffordId,
+    CNOT, CPhase, SWAP, Hadamard, Phase, CliffordId,
     tensor_pow,
     stab_to_gf2, gf2_gausselim!, gf2_isinvertible, gf2_invert, gf2_H_to_G,
     perm_inverse, perm_product,
@@ -1712,6 +1712,11 @@ const CNOTcol = Ccol"XX
                      ZI
                      ZZ"
 
+const CPhasecol = C"XZ
+                    ZX
+                    ZI
+                    IZ"
+
 const SWAPcol = Ccol"IX
                      XI
                      IZ
@@ -1731,6 +1736,11 @@ const CNOT = C"XX
                IX
                ZI
                ZZ"
+
+const CPhase = C"XZ
+                 ZX
+                 ZI
+                 IZ"
 
 const SWAP = C"IX
                XI

--- a/src/SimpleClifford.jl
+++ b/src/SimpleClifford.jl
@@ -1432,7 +1432,7 @@ function apply!(s::Stabilizer, c::CliffordOperator; phases::Bool=true)
     s
 end
 
-function apply!(s::Stabilizer, c::CliffordOperator, indices_of_appweightlication::AbstractArray{T,1} where T; phases::Bool=true) # TODO why T and not Int?
+function apply!(s::Stabilizer, c::CliffordOperator, indices_of_application::AbstractArray{T,1} where T; phases::Bool=true) # TODO why T and not Int?
     new_stabrow = zero(c.tab[1])
     n = nqubits(c)
     for row_stab in eachindex(s)


### PR DESCRIPTION
The aim of this PR is to fix an error that was introduced in the [last commit](https://github.com/Krastanov/SimpleClifford/commit/d21d50cfb32b936823a78e09b67e00ba17f42e00)  and caused the [Travis build to fail](https://travis-ci.com/github/Krastanov/SimpleClifford/jobs/326114377#L224). The error reads as follows:
`  UndefVarError: indices_of_application not defined`
 and is due to a spelling error in the function signature of the sparse apply of CliffordOperators:
`function apply!(s::Stabilizer, c::CliffordOperator, indices_of_appweightlication::AbstractArray{T,1} where T; phases::Bool=true)
`
the `indices_of_application ` have been corrected!

I also added a constant for the CPhase gate as it may be very useful for other people to define this in the framework. Should we also add a document entry to explain how a Chase gate can be obtained and show an example?