### PR TITLE
Feature: alternative approach to perturbative trajectories

### DIFF
--- a/src/experimental/NoisyCircuits.jl
+++ b/src/experimental/NoisyCircuits.jl
@@ -280,13 +280,16 @@ function applynoise_branches(s::Stabilizer,noise::UnbiasedUncorrelatedNoise,indi
     no_error = no_error1^l
     results = [(copy(s),no_error,0)] # state, prob, order
     for order in 1:min(max_order,l)
-        error_prob = no_error1^(l-order)*infid^order
+        error_prob1 = infid^order
         for error_indices in combinations(indices, order) # TODO clean this up, optimize it
             for error_types in Base.Iterators.product(repeat([[apply_single_x!,apply_single_y!,apply_single_z!]],order)...)
                 new_state = copy(s)
+                max_index = 0
                 for (i,t) in zip(error_indices, error_types)
                     t(new_state,i)
+                    max_index = max(max_index, i)
                 end
+                error_prob = no_error1^((max_index-order)+min((l-max_index),(max_order-order)))*error_prob1
                 push!(results,(new_state, error_prob, order))
             end
         end


### PR DESCRIPTION
Previously, the noise applied to branches in the perturbative expansion strategy traces the trajectory by ignoring branches having more errors than the maximum order. This led to the total probability being <1 when the order was less than the maximum order. This commit implements an alternative method of approximation where a branch is terminated when the number of errors applied in that branch reaches the maximum order limit. This should lead to the total probability being 1.

The previous version of the trajectory allows one to estimate the amount of approximation, that is related to the number of branches ignored, by calculating how far the total probability is, from 1. This option is missing in the new approach.