### PR TITLE
Improve performance of fill_tril

### DIFF
--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -246,8 +246,8 @@ end
 """Assign (symmetric) random ints to off diagonals of matrix."""
 function fill_tril(rng, matrix, n; symmetric::Bool=false)
     # Add (symmetric) random ints to off diagonals
-    for row in 1:n, col in 1:row-1
-        b = rand(rng, 0:1)
+    @inbounds for row in 1:n, col in 1:row-1
+        b = rand(rng, (0, 1))
         matrix[row, col] = b
         if symmetric
             matrix[col, row] = b

--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -247,7 +247,7 @@ end
 function fill_tril(rng, matrix, n; symmetric::Bool=false)
     # Add (symmetric) random ints to off diagonals
     @inbounds for row in 1:n, col in 1:row-1
-        b = rand(rng, (0, 1))
+        b = rand(rng, Bool)
         matrix[row, col] = b
         if symmetric
             matrix[col, row] = b


### PR DESCRIPTION
Use @inbounds to improve performance a bit.
Use Tuple (0,1) rather than range 0:1.

Using small Tuples rather than Arrays or other types often gives a
performance increase.

With this PR, for 200x200 Matrix{Int8}, fill_tril is more than twice as fast.