### PR TITLE
closes #49

### DIFF
--- a/src/randoms.jl
+++ b/src/randoms.jl
@@ -175,66 +175,26 @@ end
 
 """Sample (h, S) from the distribution P_n(h, S) from Bravyi and Maslov Algorithm 1."""
 function quantum_mallows(rng, n) # each one is benchmakred in benchmarks/quantum_mallows.jl
-    if n<30 # TODO Do in a prettier way without repetition.
-        quantum_mallows_int(rng, n)
-    elseif n<500
-        quantum_mallows_float(rng, n)
-    else
-        quantum_mallows_bigint(rng, n)
-    end
-end
-
-"""This function is correct for n<30"""
-function quantum_mallows_int(rng, n)
     arr = collect(1:n)
     hadamard = falses(n)
     perm = zeros(Int64, n)
     for idx in 1:n
         m = length(arr)
         # sample h_i from given prob distribution
-        k = rand(rng, 2:UInt(4)^m)
-        l = ilog2(k, RoundUp)
-        weight = 2 * m - l
-        hadamard[idx] = (weight < m)
-        k = weight < m ? weight : 2*m - weight - 1
-        perm[idx] = popat!(arr, k + 1)
-    end
-    return hadamard, perm
-end
-
-"""This function is correct for n<500, but slower than `quantum_mallows_int`."""
-function quantum_mallows_float(rng, n)
-    arr = collect(1:n)
-    hadamard = falses(n)
-    perm = zeros(Int64, n)
-    for idx in 1:n
-        m = length(arr)
-        # sample h_i from given prob distribution
-        k = rand(rng)*(4.0^m-1) + 1
-        l = ceil(log2(k))
-        weight = Int64(2 * m - l)
-        hadamard[idx] = (weight < m)
-        k = weight < m ? weight : 2*m - weight - 1
-        perm[idx] = popat!(arr, k + 1)
-    end
-    return hadamard, perm
-end
-
-"""This function is correct for any n, but slower than `quantum_mallows_float`."""
-function quantum_mallows_bigint(rng, n)
-    arr = collect(1:n)
-    hadamard = falses(n)
-    perm = zeros(Int64, n)
-    for idx in 1:n
-        m = length(arr)
-        # sample h_i from given prob distribution
-        k = rand(rng, 2:BIG_INT_FOUR[]^m)
+        if n < 30
+            k = rand(rng, 2:UInt(4)^m)
+        elseif n < 500
+            k = rand(rng)*(4.0^m-1) + 1
+        else
+            k = rand(rng, 2:BigInt(4)^m)
+        end
         l = ilog2(k, RoundUp)
         weight = Int64(2 * m - l)
         hadamard[idx] = (weight < m)
         k = weight < m ? weight : 2*m - weight - 1
         perm[idx] = popat!(arr, k + 1)
     end
+    # return hadamard (h) and permutation (S)
     return hadamard, perm
 end
 


### PR DESCRIPTION
## Issue
The three functions for `quantum_mallows` (`_int`, `_bigint` and `_float`) were needed because `ilog2` had some bugs.
Now that it is fixed, they are no longer required.

## Solution
Merged the three functions into the existing `quantum_mallows` and added an if statement that is needed because of the `rand` function which cannot be written in a similar range type for Float as for Int and BigInt. Also writing it as `rand() * number` for all ranges of n slows it down drastically.

## Improvements
- Cleaner code
- A bit of time unplanned-for time improvement